### PR TITLE
Fix bug in MS_decomp for triclinic part

### DIFF
--- a/msat/MS_decomp.m
+++ b/msat/MS_decomp.m
@@ -78,7 +78,7 @@ function [ varargout ] = MS_decomp( C )
       C=C-CH ;
    end
 
-   if (nargout==6), varargout{6} = CH;, end
+   if (nargout==6), varargout{6} = C;, end
    
 
 return


### PR DESCRIPTION
Previous versions of MS_decomp() erroneously returned the monoclinic
part as the triclinic as well, so the two were identical, and
C != Ciso + Chex + Ctet + Cort + Cmon + Ctri.