### PR TITLE
Fix case 'nofig' of 'MS_sphere.m'

### DIFF
--- a/msat/MS_sphere.m
+++ b/msat/MS_sphere.m
@@ -196,7 +196,7 @@ end
                plotaxes = 0 ;
                iarg = iarg + 1 ;
             case 'nofig'
-               nofig = 0 ;
+               nofig = 1 ;
                iarg = iarg + 1 ;
             case 'nocbar'
                nocbar = 0 ;


### PR DESCRIPTION
This PR aims to fix the case `'nofig'` in the function `MS_sphere.m`.
> Suppress the figure command, so plot can be sub-plotted.

A figure is set up if the variable `nofig` is unequal to `1`,  see lines 268-270:
```matlab
if (nofig~=1)
    figure('position',[0 0 800 800])
end
```

So, to _not_ set up a figure (passing `'nofig'`  to `MS_sphere.m`) the variable `nofig` has to be `1` not `0`, see lines 198-200: 
```matlab
case 'nofig'
    nofig = 1 ; % <- instead of 0
    iarg = iarg + 1 ;
```