### PR TITLE
Fix case 'nocbar' in 'MS_sphere.m'

### DIFF
--- a/msat/MS_sphere.m
+++ b/msat/MS_sphere.m
@@ -199,7 +199,7 @@ end
                nofig = 0 ;
                iarg = iarg + 1 ;
             case 'nocbar'
-               nocbar = 0 ;
+               nocbar = 1 ;
                iarg = iarg + 1 ;
             case 'cmap'
                cmarg = varargin{iarg+1} ;


### PR DESCRIPTION
This PR aims to fix the case `'nocbar'` in the function `MS_sphere.m`.
> Supress printing of the colour bar.

A colorbar is added if the variable `nocbar` is unequal to `1`, see lines 493-494:
```matlab
if (nocbar~=1)
    cbax = colorbar('NorthOutside','FontSize',14,'FontWeight','bold');
    % ...
end
```

So, to _not_ add a colorbar (passing `'nocbar'`  to `MS_sphere.m`) the variable `nocbar`  has to be `1` not `0`, see lines 201-203:
```matlab
case 'nocbar'
    nocbar = 1 ; % <- instead of 0
    iarg = iarg + 1 ;
```